### PR TITLE
Adjust test execution

### DIFF
--- a/packages/crystfel/package.py
+++ b/packages/crystfel/package.py
@@ -25,8 +25,8 @@ from spack import *
 
 class Crystfel(CMakePackage):
     """CrystFEL is a suite of programs for processing (and simulating) Bragg
-       diffraction data from "serial crystallography" experiments, often (but
-       not always) performed using an X-ray Free-Electron Laser.
+    diffraction data from "serial crystallography" experiments, often (but
+    not always) performed using an X-ray Free-Electron Laser.
     """
 
     # FIXME: Add a proper url for your package's homepage here.

--- a/packages/py-extra-data/package.py
+++ b/packages/py-extra-data/package.py
@@ -43,28 +43,24 @@ class PyExtraData(PythonPackage):
     depends_on('py-setuptools', type='build')
     depends_on('py-fabio') #  custom
     depends_on('py-h5py@2.7.1:')
-    depends_on('py-karabo-bridge@0.6:') #  custom
+    depends_on('py-karabo-bridge@0.6:')  # custom
     depends_on('py-matplotlib')
     depends_on('py-numpy')
     depends_on('py-pandas')
     depends_on('py-scipy')
     depends_on('py-xarray')
 
-    depends_on ('py-coverage', type='test')
-    depends_on ('py-dask', type='test')
-    # depends_on ('py-nbval', type='test') #  Doesn't seem to be needed?
-    depends_on ('py-pytest', type='test')
-    depends_on ('py-pytest-cov', type='test')
-    depends_on ('py-testpath', type='test')
+    depends_on('py-coverage', type='test')
+    depends_on('py-dask', type='test')
+    # depends_on('py-nbval', type='test') #  Doesn't seem to be needed?
+    depends_on('py-pytest', type='test')
+    depends_on('py-pytest-cov', type='test')
+    depends_on('py-testpath', type='test')
 
     def test(self):
         # `setup.py test` should not be used as:
         #   - `python3 -m pytest -v` should be ran instead
         #   - the builtin `test` method runs before `install` is finished
-        pass
-
-    @run_after('install')
-    def pytest(self):
         with working_dir('.'):
             prefix = self.spec.prefix
             #  Add bin to path here, as tests also check entrypoints

--- a/packages/py-extra-geom/package.py
+++ b/packages/py-extra-geom/package.py
@@ -52,19 +52,15 @@ class PyExtraGeom(PythonPackage):
     depends_on('py-numpy')
     depends_on('py-scipy')
 
-    depends_on ('py-coverage@:4.9', type='test')
-    depends_on ('py-pytest', type='test')
-    depends_on ('py-pytest-cov', type='test')
-    depends_on ('py-testpath', type='test')
+    depends_on('py-coverage@:4.9', type='test')
+    depends_on('py-pytest', type='test')
+    depends_on('py-pytest-cov', type='test')
+    depends_on('py-testpath', type='test')
 
     def test(self):
         # `setup.py test` should not be used as:
         #   - `python3 -m pytest -v` should be ran instead
         #   - the builtin `test` method runs before `install` is finished
-        pass
-
-    @run_after('install')
-    def pytest(self):
         with working_dir('.'):
             prefix = self.spec.prefix
             #  Add bin to path here, as tests also check entrypoints

--- a/packages/py-fabio/package.py
+++ b/packages/py-fabio/package.py
@@ -48,6 +48,7 @@ class PyFabio(PythonPackage):
     depends_on('python@3.6:',   type=('build', 'run'))
     depends_on('py-setuptools', type='build')
     depends_on('py-numpy')
+
     def build_args(self, spec, prefix):
         # FIXME: Add arguments other than --prefix
         # FIXME: If not needed delete this function

--- a/packages/py-karabo-bridge/package.py
+++ b/packages/py-karabo-bridge/package.py
@@ -56,7 +56,6 @@ class PyKaraboBridge(PythonPackage):
     depends_on('py-h5py',       type=('test'))
     depends_on('py-testpath',   type=('test'))
 
-
     def build_args(self, spec, prefix):
         # FIXME: Add arguments other than --prefix
         # FIXME: If not needed delete this function


### PR DESCRIPTION
- Minor formatting changes.
- Fixes test execution - tests mistakenly ran with `@run_after('install')`, so they would run even if not requested, no longer does that.